### PR TITLE
강좌 관련 동시성 제어

### DIFF
--- a/src/main/java/com/example/exodia/car/controller/CarController.java
+++ b/src/main/java/com/example/exodia/car/controller/CarController.java
@@ -1,0 +1,28 @@
+package com.example.exodia.car.controller;
+
+import com.example.exodia.car.domain.Car;
+import com.example.exodia.car.dto.CarResponseDto;
+import com.example.exodia.car.repository.CarRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/car")
+public class CarController {
+
+    @Autowired
+    private CarRepository carRepository;
+
+    @GetMapping("/list")
+    public List<CarResponseDto> getCarList() {
+        List<Car> cars = carRepository.findAll();
+        return cars.stream()
+                .map(CarResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/exodia/car/domain/Car.java
+++ b/src/main/java/com/example/exodia/car/domain/Car.java
@@ -19,9 +19,18 @@ public class Car {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String carNum; // 차량 기종
+    private String carNum; // 차량 번호
 
     @Column(nullable = false)
     private String carType; // 차량 타입
+
+    @Column(nullable = false)
+    private int seatingCapacity; // 차량 인승
+
+    @Column(nullable = false)
+    private double engineDisplacement; // 베기량 (cc)
+
+    @Column(nullable = false)
+    private String carImage;
 
 }

--- a/src/main/java/com/example/exodia/car/dto/CarResponseDto.java
+++ b/src/main/java/com/example/exodia/car/dto/CarResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.exodia.car.dto;
+
+import com.example.exodia.car.domain.Car;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CarResponseDto {
+    private Long id;
+    private String carNum;
+    private String carType;
+    private int seatingCapacity;
+    private double engineDisplacement;
+    private String carImage;
+
+    public static CarResponseDto fromEntity(Car car) {
+        return CarResponseDto.builder()
+                .id(car.getId())
+                .carNum(car.getCarNum())
+                .carType(car.getCarType())
+                .seatingCapacity(car.getSeatingCapacity())
+                .engineDisplacement(car.getEngineDisplacement())
+                .carImage(car.getCarImage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/exodia/common/config/KafkaProducerConfig.java
+++ b/src/main/java/com/example/exodia/common/config/KafkaProducerConfig.java
@@ -1,0 +1,36 @@
+package com.example.exodia.common.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"); // 서버 주소
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        // 중복 방지 설정
+        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 10);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/example/exodia/common/config/RedisConfig.java
+++ b/src/main/java/com/example/exodia/common/config/RedisConfig.java
@@ -251,5 +251,23 @@ public class RedisConfig {
     }
 
 
+    /* 강의 인원수만큼 제어*/
+    @Bean
+    @Qualifier("12")
+    LettuceConnectionFactory courseParticipantConnectionFactory() {
+        return redisConnectionFactory(11);
+    }
+
+    @Bean
+    @Qualifier("12")
+    public RedisTemplate<String, Object> courseParticipantRedisTemplate(@Qualifier("12") LettuceConnectionFactory courseParticipantConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(courseParticipantConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+
+
 
 }

--- a/src/main/java/com/example/exodia/common/data/InitialDataLoader.java
+++ b/src/main/java/com/example/exodia/common/data/InitialDataLoader.java
@@ -264,13 +264,13 @@ public class InitialDataLoader implements CommandLineRunner {
 
 
         List<Car> cars = new ArrayList<>();
-        cars.add(new Car(null, "121가123", "스타랙스"));
-        cars.add(new Car(null, "135나894", "밴츠"));
-        cars.add(new Car(null, "753호159", "SUV"));
-        cars.add(new Car(null, "143라3451", "람보르기니"));
-        cars.add(new Car(null, "429호7318", "G70"));
-        cars.add(new Car(null, "14라 8222", "소나타"));
-        cars.add(new Car(null, "18유3752", "황금마티즈"));
+        cars.add(new Car(null, "121가123", "스타랙스", 11, 2.5, "starrex.jpg"));
+        cars.add(new Car(null, "135나894", "밴츠", 5, 3.0, "benz.jpg"));
+        cars.add(new Car(null, "753호159", "SUV", 7, 2.0, "suv.jpg"));
+        cars.add(new Car(null, "143라3451", "람보르기니", 2, 5.2, "lamborghini.jpg"));
+        cars.add(new Car(null, "429호7318", "G70", 5, 3.3, "g70.jpg"));
+        cars.add(new Car(null, "14라 8222", "소나타", 5, 2.0, "sonata.jpg"));
+        cars.add(new Car(null, "18유3752", "황금마티즈", 4, 0.8, "matiz.jpg"));
         carRepository.saveAll(cars);
       
         submitTypeRepository.save(new SubmitType(1L, "법인 카드 신청"));

--- a/src/main/java/com/example/exodia/common/service/KafkaProducer.java
+++ b/src/main/java/com/example/exodia/common/service/KafkaProducer.java
@@ -41,5 +41,11 @@ public class KafkaProducer {
         System.out.println("Kafka 문서 업데이트 이벤트: " + message);
     }
 
+
+    // 강좌
+    public void sendCourseRegistrationEvent(String courseId, String message) {
+        kafkaTemplate.send("course-registration", courseId, message);
+        System.out.println("Kafka 강좌 등록 이벤트 전송: " + message + " / 코스 ID: " + courseId);
+    }
 }
 

--- a/src/main/java/com/example/exodia/course/controller/CourseController.java
+++ b/src/main/java/com/example/exodia/course/controller/CourseController.java
@@ -1,9 +1,13 @@
     package com.example.exodia.course.controller;
 
+    import com.example.exodia.course.domain.Course;
     import com.example.exodia.course.dto.CourseCreateDto;
     import com.example.exodia.course.dto.CourseListDto;
     import com.example.exodia.course.dto.CourseUpdateDto;
     import com.example.exodia.course.service.CourseService;
+    import com.example.exodia.registration.dto.RegistrationDto;
+    import com.example.exodia.registration.repository.RegistrationRepository;
+    import com.example.exodia.registration.service.RegistrationService;
     import org.springframework.http.ResponseEntity;
     import org.springframework.web.bind.annotation.*;
 
@@ -14,22 +18,27 @@
 public class CourseController {
 
     private final CourseService courseService;
+    private final RegistrationService registrationService;
+    private final RegistrationRepository registrationRepository;
 
-    public CourseController(CourseService courseService) {
+    public CourseController(CourseService courseService, RegistrationService registrationService, RegistrationRepository registrationRepository) {
         this.courseService = courseService;
+        this.registrationService = registrationService;
+        this.registrationRepository = registrationRepository;
     }
 
     /* 강좌 생성 */
     @PostMapping("/create")
     public ResponseEntity<CourseListDto> createCourse(@RequestBody CourseCreateDto courseCreateDto) {
-        CourseListDto createdCourse = CourseListDto.fromEntity(courseService.createCourse(courseCreateDto));
-        return ResponseEntity.ok(createdCourse);
+        Course createdCourse = courseService.createCourse(courseCreateDto);
+        int currentParticipants = 0;
+        CourseListDto createdCourseDto = CourseListDto.fromEntity(createdCourse, currentParticipants);
+        return ResponseEntity.ok(createdCourseDto);
     }
 
     /* 강좌 업데이트  */
     @PutMapping("/update/{courseId}")
-    public ResponseEntity<CourseListDto> updateCourse(@RequestBody CourseUpdateDto courseUpdateDto,
-                                                      @PathVariable Long courseId) {
+    public ResponseEntity<CourseListDto> updateCourse(@RequestBody CourseUpdateDto courseUpdateDto, @PathVariable Long courseId) {
         CourseListDto updatedCourse = courseService.updateCourse(courseUpdateDto, courseId);
         return ResponseEntity.ok(updatedCourse);
     }
@@ -47,4 +56,19 @@ public class CourseController {
         courseService.softDeleteCourse(courseId);
         return ResponseEntity.ok().build();
     }
+
+    /* 강좌 신청 */
+    @PostMapping("/register/{courseId}")
+    public ResponseEntity<String> registerParticipant(@PathVariable Long courseId) {
+        String result = registrationService.registerParticipant(courseId);
+        return ResponseEntity.ok(result);
+    }
+
+    /* 강좌 확정 인원 조회*/
+    @GetMapping("/{courseId}/confirmed")
+    public ResponseEntity<List<RegistrationDto>> getConfirmedParticipants(@PathVariable Long courseId) {
+        List<RegistrationDto> confirmedParticipants = registrationService.getConfirmedParticipants(courseId);
+        return ResponseEntity.ok(confirmedParticipants);
+    }
+
 }

--- a/src/main/java/com/example/exodia/course/controller/CourseController.java
+++ b/src/main/java/com/example/exodia/course/controller/CourseController.java
@@ -1,0 +1,50 @@
+    package com.example.exodia.course.controller;
+
+    import com.example.exodia.course.dto.CourseCreateDto;
+    import com.example.exodia.course.dto.CourseListDto;
+    import com.example.exodia.course.dto.CourseUpdateDto;
+    import com.example.exodia.course.service.CourseService;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.*;
+
+    import java.util.List;
+
+@RestController
+@RequestMapping("/course")
+public class CourseController {
+
+    private final CourseService courseService;
+
+    public CourseController(CourseService courseService) {
+        this.courseService = courseService;
+    }
+
+    /* 강좌 생성 */
+    @PostMapping("/create")
+    public ResponseEntity<CourseListDto> createCourse(@RequestBody CourseCreateDto courseCreateDto) {
+        CourseListDto createdCourse = CourseListDto.fromEntity(courseService.createCourse(courseCreateDto));
+        return ResponseEntity.ok(createdCourse);
+    }
+
+    /* 강좌 업데이트  */
+    @PutMapping("/update/{courseId}")
+    public ResponseEntity<CourseListDto> updateCourse(@RequestBody CourseUpdateDto courseUpdateDto,
+                                                      @PathVariable Long courseId) {
+        CourseListDto updatedCourse = courseService.updateCourse(courseUpdateDto, courseId);
+        return ResponseEntity.ok(updatedCourse);
+    }
+
+    /* 강좌 리스트 */
+    @GetMapping("/list")
+    public ResponseEntity<List<CourseListDto>> listCourses() {
+        List<CourseListDto> courses = courseService.listCourses();
+        return ResponseEntity.ok(courses);
+    }
+
+    /* 강좌 삭제 */
+    @PutMapping("/delete/{courseId}")
+    public ResponseEntity<Void> deleteCourse(@PathVariable Long courseId) {
+        courseService.softDeleteCourse(courseId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/exodia/course/domain/Course.java
+++ b/src/main/java/com/example/exodia/course/domain/Course.java
@@ -1,0 +1,33 @@
+package com.example.exodia.course.domain;
+
+import com.example.exodia.common.domain.BaseTimeEntity;
+import com.example.exodia.common.domain.DelYN;
+import com.example.exodia.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class Course extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String courseName;
+
+    private String courseUrl;
+
+    private int maxParticipants;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_num", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/example/exodia/course/dto/CourseCreateDto.java
+++ b/src/main/java/com/example/exodia/course/dto/CourseCreateDto.java
@@ -1,0 +1,32 @@
+package com.example.exodia.course.dto;
+
+import com.example.exodia.common.domain.DelYN;
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CourseCreateDto {
+
+    private String courseName;
+    private String courseUrl;
+    private int maxParticipants;
+
+    public Course toEntity(User user) {
+        return Course.builder()
+                .courseName(this.courseName)
+                .courseUrl(this.courseUrl)
+                .maxParticipants(this.maxParticipants)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/example/exodia/course/dto/CourseListDto.java
+++ b/src/main/java/com/example/exodia/course/dto/CourseListDto.java
@@ -1,0 +1,37 @@
+package com.example.exodia.course.dto;
+
+import com.example.exodia.course.domain.Course;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CourseListDto {
+
+    private Long id;
+    private String courseName;
+    private String courseUrl;
+    private int maxParticipants;
+    private String UserDepartmentName; // 유저의 부서명 받을꺼
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CourseListDto fromEntity(Course course) {
+        return CourseListDto.builder()
+                .id(course.getId())
+                .courseName(course.getCourseName())
+                .courseUrl(course.getCourseUrl())
+                .maxParticipants(course.getMaxParticipants())
+                .UserDepartmentName(course.getUser().getDepartment().getName())
+                .createdAt(course.getCreatedAt())
+                .updatedAt(course.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/exodia/course/dto/CourseListDto.java
+++ b/src/main/java/com/example/exodia/course/dto/CourseListDto.java
@@ -17,17 +17,19 @@ public class CourseListDto {
     private Long id;
     private String courseName;
     private String courseUrl;
-    private int maxParticipants;
+    private int maxParticipants; // 최대 신청인원
+    private int remainingParticipants; // 남은 신청인원 ( 최대 - 신청 )
     private String UserDepartmentName; // 유저의 부서명 받을꺼
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static CourseListDto fromEntity(Course course) {
+    public static CourseListDto fromEntity(Course course, int currentParticipants) {
         return CourseListDto.builder()
                 .id(course.getId())
                 .courseName(course.getCourseName())
                 .courseUrl(course.getCourseUrl())
                 .maxParticipants(course.getMaxParticipants())
+                .remainingParticipants(course.getMaxParticipants() - currentParticipants)
                 .UserDepartmentName(course.getUser().getDepartment().getName())
                 .createdAt(course.getCreatedAt())
                 .updatedAt(course.getUpdatedAt())

--- a/src/main/java/com/example/exodia/course/dto/CourseUpdateDto.java
+++ b/src/main/java/com/example/exodia/course/dto/CourseUpdateDto.java
@@ -1,0 +1,29 @@
+package com.example.exodia.course.dto;
+
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CourseUpdateDto {
+
+    private String courseName;
+    private String courseUrl;
+    private int maxParticipants;
+
+    public Course toEntity(Course existingCourse, User user) {
+        return Course.builder()
+                .id(existingCourse.getId())
+                .courseName(this.courseName)
+                .courseUrl(this.courseUrl)
+                .maxParticipants(this.maxParticipants)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/example/exodia/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/exodia/course/repository/CourseRepository.java
@@ -1,0 +1,11 @@
+package com.example.exodia.course.repository;
+
+import com.example.exodia.common.domain.DelYN;
+import com.example.exodia.course.domain.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+    List<Course> findByDelYn(DelYN delYn);
+}

--- a/src/main/java/com/example/exodia/course/service/CourseService.java
+++ b/src/main/java/com/example/exodia/course/service/CourseService.java
@@ -1,0 +1,93 @@
+package com.example.exodia.course.service;
+
+import com.example.exodia.common.domain.DelYN;
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.course.dto.CourseCreateDto;
+import com.example.exodia.course.dto.CourseListDto;
+import com.example.exodia.course.dto.CourseUpdateDto;
+import com.example.exodia.course.repository.CourseRepository;
+import com.example.exodia.meetingRoom.domain.MeetingRoom;
+import com.example.exodia.user.domain.User;
+import com.example.exodia.user.repository.UserRepository;
+import com.example.exodia.user.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
+
+    public CourseService(CourseRepository courseRepository, UserRepository userRepository, UserService userService) {
+        this.courseRepository = courseRepository;
+        this.userRepository = userRepository;
+        this.userService = userService;
+    }
+
+    /* 강좌 생성 */
+    @Transactional
+    public Course createCourse(CourseCreateDto dto) {
+        String userNum = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByUserNum(userNum)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+        userService.checkHrAuthority(user.getDepartment().getId().toString());
+
+//        if (courseRepository.findByName(createDto.getName()).isPresent()) {
+//            throw new IllegalArgumentException("이미 존재하는 강의명입니다.");
+//        }
+        Course course = dto.toEntity(user);
+        return courseRepository.save(course);
+    }
+
+    /* 강좌 업데이트 */
+    @Transactional
+    public CourseListDto updateCourse(CourseUpdateDto dto, Long courseId) {
+        String userNum = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByUserNum(userNum)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+        Course existingCourse = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 강좌입니다."));
+
+        userService.checkHrAuthority(user.getDepartment().getId().toString());
+
+        Course updatedCourse = dto.toEntity(existingCourse, user);
+        return CourseListDto.fromEntity(courseRepository.save(updatedCourse));
+    }
+
+    /* 강좌 리스트*/
+    public List<CourseListDto> listCourses() {
+        // 강좌 리스트는 모든 유저가 다 볼 수 있어야함
+        return courseRepository.findByDelYn(DelYN.N).stream()
+                .map(CourseListDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    /* 강좌 삭제 */
+    @Transactional
+    public void softDeleteCourse(Long courseId) {
+        String userNum = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByUserNum(userNum)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+
+        userService.checkHrAuthority(user.getDepartment().getId().toString());
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 강좌입니다."));
+
+        // 강좌 생성자와 요청한 사용자가 동일한지 체크하거나 관리자 권한 체크
+        if (!course.getUser().getUserNum().equals(userNum)) {
+            throw new SecurityException("해당 강좌를 삭제할 권한이 없습니다.");
+        }
+        course.softDelete();
+        courseRepository.save(course);
+    }
+
+}

--- a/src/main/java/com/example/exodia/registration/domain/Registration.java
+++ b/src/main/java/com/example/exodia/registration/domain/Registration.java
@@ -1,0 +1,28 @@
+package com.example.exodia.registration.domain;
+
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Registration {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "registration_status", nullable = false)
+    private String registrationStatus;
+}

--- a/src/main/java/com/example/exodia/registration/dto/RegistrationCreateDto.java
+++ b/src/main/java/com/example/exodia/registration/dto/RegistrationCreateDto.java
@@ -1,0 +1,28 @@
+package com.example.exodia.registration.dto;
+
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.registration.domain.Registration;
+import com.example.exodia.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegistrationCreateDto {
+    private Long courseId;
+    private String userNum;
+    private String registrationStatus;
+
+    public Registration toEntity(Course course, User user) {
+        return Registration.builder()
+                .course(course)
+                .user(user)
+                .registrationStatus(this.registrationStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/exodia/registration/dto/RegistrationDto.java
+++ b/src/main/java/com/example/exodia/registration/dto/RegistrationDto.java
@@ -1,0 +1,13 @@
+package com.example.exodia.registration.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistrationDto {
+    private String userNum;
+    private String userName;
+}

--- a/src/main/java/com/example/exodia/registration/repository/RegistrationRepository.java
+++ b/src/main/java/com/example/exodia/registration/repository/RegistrationRepository.java
@@ -1,0 +1,14 @@
+package com.example.exodia.registration.repository;
+
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.registration.domain.Registration;
+import com.example.exodia.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+    boolean existsByCourseAndUser(Course course, User user);
+    List<Registration> findAllByCourseAndRegistrationStatus(Course course, String registrationStatus);
+    int countByCourse(Course course);
+}

--- a/src/main/java/com/example/exodia/registration/service/RegistrationService.java
+++ b/src/main/java/com/example/exodia/registration/service/RegistrationService.java
@@ -1,0 +1,111 @@
+package com.example.exodia.registration.service;
+
+
+import com.example.exodia.common.service.KafkaProducer;
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.course.repository.CourseRepository;
+import com.example.exodia.registration.domain.Registration;
+import com.example.exodia.registration.dto.RegistrationCreateDto;
+import com.example.exodia.registration.dto.RegistrationDto;
+import com.example.exodia.registration.repository.RegistrationRepository;
+import com.example.exodia.user.domain.User;
+import com.example.exodia.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class RegistrationService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final KafkaProducer kafkaProducer;
+    private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
+    private final RegistrationRepository registrationRepository;
+
+    @Autowired
+    public RegistrationService(@Qualifier("12") RedisTemplate<String, Object> redisTemplate,
+                               KafkaProducer kafkaProducer, CourseRepository courseRepository, UserRepository userRepository, RegistrationRepository registrationRepository) {
+        this.redisTemplate = redisTemplate;
+        this.kafkaProducer = kafkaProducer;
+        this.courseRepository = courseRepository;
+        this.userRepository = userRepository;
+        this.registrationRepository = registrationRepository;
+    }
+
+    @Transactional
+    public String registerParticipant(Long courseId) {
+        String userNum = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByUserNum(userNum)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("강좌를 찾을 수 없습니다."));
+
+        if (registrationRepository.existsByCourseAndUser(course, user)) {
+            return "이미 해당 강좌에 등록된 사용자입니다.";
+        }
+        String redisKey = "course:" + courseId + ":participants";
+
+        Long currentParticipants = redisTemplate.opsForValue().increment(redisKey); // 증가
+
+        if (currentParticipants > getMaxParticipants(courseId)) {
+            // if 초과 -> Redis 증가 값 롤백
+            redisTemplate.opsForValue().decrement(redisKey);
+            return "참가자 수가 초과되었습니다.";
+        }
+
+        // Kafka producer ->  등록 이벤트 전송
+        String message = "User " + userNum + " has registered for course " + courseId;
+        kafkaProducer.sendCourseRegistrationEvent(courseId.toString(), message);
+
+        return "등록 완료";
+    }
+
+    // 데이터베이스에서 강좌의 최대 참가자 수 조회
+    public int getMaxParticipants(Long courseId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("강좌를 찾을 수 없습니다."));
+        return course.getMaxParticipants();
+    }
+
+
+    // 강좌 등록
+    @Transactional
+    public void confirmRegistration(Long courseId, String userNum) {
+
+        User user = userRepository.findByUserNum(userNum)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("강좌를 찾을 수 없습니다."));
+
+        // 이미 등록된 사용자인지 확인
+        if (registrationRepository.existsByCourseAndUser(course, user)) {
+            System.out.println("이미 등록된 사용자입니다.");
+            return;
+        }
+
+        Registration participant = new RegistrationCreateDto(courseId, userNum, "confirmed").toEntity(course, user);
+
+        registrationRepository.save(participant);
+        System.out.println("User " + userNum + "가 강좌 " + courseId + "에 성공적으로 등록되었습니다.");//
+    }
+
+
+    public List<RegistrationDto> getConfirmedParticipants(Long courseId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException("강좌를 찾을 수 없습니다."));
+
+        return registrationRepository.findAllByCourseAndRegistrationStatus(course, "confirmed").stream()
+                .map(registration -> new RegistrationDto(registration.getUser().getUserNum(), registration.getUser().getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/exodia/registration/service/RegistrationService.java
+++ b/src/main/java/com/example/exodia/registration/service/RegistrationService.java
@@ -99,7 +99,7 @@ public class RegistrationService {
         System.out.println("User " + userNum + "가 강좌 " + courseId + "에 성공적으로 등록되었습니다.");//
     }
 
-
+    @Transactional
     public List<RegistrationDto> getConfirmedParticipants(Long courseId) {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException("강좌를 찾을 수 없습니다."));

--- a/src/main/java/com/example/exodia/reservationVehicle/dto/ReservationCreateDto.java
+++ b/src/main/java/com/example/exodia/reservationVehicle/dto/ReservationCreateDto.java
@@ -21,17 +21,18 @@ public class ReservationCreateDto {
 
     private Long carId;
     private LocalDate startDate; // 날짜만 입력 받음
+    private LocalDate endDate;
 
     public Reservation toEntity(Car car, User user) {
         // 하루 예약 처리: 해당 날짜의 시작과 끝 시간 설정
-        LocalDateTime startTime = startDate.atStartOfDay();
-        LocalDateTime endTime = startDate.atTime(LocalTime.MAX); // 59:59:9999
+//        LocalDateTime startTime = startDate.atStartOfDay();
+//        LocalDateTime endTime = startDate.atTime(LocalTime.MAX); // 59:59:9999
 
         return Reservation.builder()
                 .car(car)
                 .user(user)
-                .startTime(startTime)
-                .endTime(endTime)
+                .startTime(startDate.atStartOfDay()) // 시작 날짜의 시작 시간
+                .endTime(endDate.atTime(23, 59, 59))
                 .status(Status.WAITING) // AVAILABLE -> WAITING
                 .build();
     }

--- a/src/main/java/com/example/exodia/reservationVehicle/repository/ReservationRepository.java
+++ b/src/main/java/com/example/exodia/reservationVehicle/repository/ReservationRepository.java
@@ -13,13 +13,20 @@ import java.util.List;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     // 특정 날짜에 해당 차량이 예약되어 있는지 확인
-    @Query("SELECT r FROM Reservation r WHERE r.car.id = :carId AND r.startTime < :endOfDay AND r.endTime > :startOfDay")
+    @Query("SELECT r FROM Reservation r WHERE r.car.id = :carId "
+            + "AND r.startTime < :endOfDay AND r.endTime > :startOfDay")
     List<Reservation> findByCarIdAndDate(@Param("carId") Long carId,
                                          @Param("startOfDay") LocalDateTime startOfDay,
                                          @Param("endOfDay") LocalDateTime endOfDay);
 
     // 특정 날짜에 예약된 항목을 찾기 위한 메서드
     List<Reservation> findByStartTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
+
+    @Query("SELECT r FROM Reservation r WHERE r.car.id = :carId " +
+            "AND (r.startTime <= :endDate AND r.endTime >= :startDate)")
+    List<Reservation> findByCarIdAndDateRange(@Param("carId") Long carId,
+                                              @Param("startDate") LocalDateTime startDate,
+                                              @Param("endDate") LocalDateTime endDate);
 }
 
 

--- a/src/main/java/com/example/exodia/user/domain/User.java
+++ b/src/main/java/com/example/exodia/user/domain/User.java
@@ -102,9 +102,9 @@ public class User extends BaseTimeEntity {
         user.setAddress(dto.getAddress());
         user.setPhone(dto.getPhone());
         user.setSocialNum(dto.getSocialNum());
-        user.setGender(dto.getGender()); // Gender enum 설정
-        user.setHireType(dto.getHireType()); // HireType enum 설정
-        user.setStatus(dto.getStatus()); // Status enum 설정
+//        user.setGender(dto.getGender()); // Gender enum 설정
+//        user.setHireType(dto.getHireType()); // HireType enum 설정
+//        user.setStatus(dto.getStatus()); // Status enum 설정
         user.setAnnualLeave(dto.getAnnualLeave());
         user.setDepartment(department);
         user.setPosition(position);

--- a/src/main/java/com/example/exodia/user/domain/User.java
+++ b/src/main/java/com/example/exodia/user/domain/User.java
@@ -102,10 +102,12 @@ public class User extends BaseTimeEntity {
         user.setAddress(dto.getAddress());
         user.setPhone(dto.getPhone());
         user.setSocialNum(dto.getSocialNum());
-        user.setHireType(dto.getHireType());
+        user.setGender(dto.getGender()); // Gender enum 설정
+        user.setHireType(dto.getHireType()); // HireType enum 설정
+        user.setStatus(dto.getStatus()); // Status enum 설정
+        user.setAnnualLeave(dto.getAnnualLeave());
         user.setDepartment(department);
         user.setPosition(position);
-        user.setAnnualLeave(dto.getAnnualLeave());
         return user;
     }
 

--- a/src/main/java/com/example/exodia/user/dto/UserRegisterDto.java
+++ b/src/main/java/com/example/exodia/user/dto/UserRegisterDto.java
@@ -13,8 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserRegisterDto {
     private String userNum;
     private String name;
-    private String gender;
-    private String status;
+    private Gender gender;
+    private Status status;
     private String password;
     private String email;
     private String address;

--- a/src/main/java/com/example/exodia/user/dto/UserRegisterDto.java
+++ b/src/main/java/com/example/exodia/user/dto/UserRegisterDto.java
@@ -13,8 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserRegisterDto {
     private String userNum;
     private String name;
-    private Gender gender;
-    private Status status;
+    private String gender;
+    private String status;
     private String password;
     private String email;
     private String address;

--- a/src/main/java/com/example/exodia/user/service/UserService.java
+++ b/src/main/java/com/example/exodia/user/service/UserService.java
@@ -7,7 +7,7 @@ import com.example.exodia.department.domain.Department;
 import com.example.exodia.department.repository.DepartmentRepository;
 import com.example.exodia.position.domain.Position;
 import com.example.exodia.position.repository.PositionRepository;
-import com.example.exodia.user.domain.User;
+import com.example.exodia.user.domain.*;
 import com.example.exodia.user.dto.*;
 import com.example.exodia.user.repository.UserRepository;
 import com.example.exodia.userDelete.domain.DeleteHistory;

--- a/src/main/java/com/example/exodia/user/service/UserService.java
+++ b/src/main/java/com/example/exodia/user/service/UserService.java
@@ -7,7 +7,7 @@ import com.example.exodia.department.domain.Department;
 import com.example.exodia.department.repository.DepartmentRepository;
 import com.example.exodia.position.domain.Position;
 import com.example.exodia.position.repository.PositionRepository;
-import com.example.exodia.user.domain.*;
+import com.example.exodia.user.domain.User;
 import com.example.exodia.user.dto.*;
 import com.example.exodia.user.repository.UserRepository;
 import com.example.exodia.userDelete.domain.DeleteHistory;
@@ -85,7 +85,6 @@ public class UserService {
             String s3ImagePath = uploadAwsFileService.uploadFileAndReturnPath(profileImage, "profile");
             newUser.setProfileImage(s3ImagePath);
         }
-
         return userRepository.save(newUser);
     }
 

--- a/src/test/java/com/example/exodia/config/KafkaConsumerTest.java
+++ b/src/test/java/com/example/exodia/config/KafkaConsumerTest.java
@@ -1,0 +1,26 @@
+package com.example.exodia.config;
+
+import com.example.exodia.common.service.KafkaConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+class KafkaConsumerTest {
+
+    @InjectMocks
+    private KafkaConsumer kafkaConsumer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testListenCourseRegistration() {
+        // 직접 메서드 호출
+        kafkaConsumer.listenCourseRegistration("course-registration", "User 123 has registered for course 1");
+
+        // 실제 처리 로직에 대한 검증 (예: 로그 메시지 또는 DB 저장 등의 로직)
+    }
+}

--- a/src/test/java/com/example/exodia/controller/CourseControllerTest.java
+++ b/src/test/java/com/example/exodia/controller/CourseControllerTest.java
@@ -1,0 +1,59 @@
+//package com.example.exodia.controller;
+//
+//import static org.mockito.ArgumentMatchers.anyLong;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.when;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+//
+//import com.example.exodia.course.controller.CourseController;
+//import com.example.exodia.registration.service.RegistrationService;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//
+//@WebMvcTest(CourseController.class)
+//class CourseControllerTest {
+//
+//    @Autowired
+//    private MockMvc mockMvc;
+//
+//    @MockBean
+//    private RegistrationService registrationService;
+//
+//    @BeforeEach
+//    void setUp() {
+//        MockitoAnnotations.openMocks(this);
+//    }
+//
+//    @Test
+//    void testRegisterParticipant() throws Exception {
+//        // Mock the registrationService to return success message
+//        when(registrationService.registerParticipant(anyLong(), anyLong())).thenReturn("등록 완료");
+//
+//        // Perform MockMvc POST request
+//        mockMvc.perform(post("/course/register/1")
+//                        .param("userId", "123"))
+//                .andExpect(status().isOk())
+//                .andExpect(content().string("등록 완료"));
+//    }
+//
+//    @Test
+//    void testRegisterParticipantExceedsMax() throws Exception {
+//        // Mock the registrationService to return error message
+//        when(registrationService.registerParticipant(anyLong(), anyLong())).thenReturn("참가자 수가 초과되었습니다.");
+//
+//        // Perform MockMvc POST request
+//        mockMvc.perform(post("/course/register/1")
+//                        .param("userId", "123"))
+//                .andExpect(status().isOk())
+//                .andExpect(content().string("참가자 수가 초과되었습니다."));
+//    }
+//}

--- a/src/test/java/com/example/exodia/reservationMeetTest/ReservationMeetPessimisticLockTest.java
+++ b/src/test/java/com/example/exodia/reservationMeetTest/ReservationMeetPessimisticLockTest.java
@@ -1,113 +1,113 @@
-package com.example.exodia.reservationMeetTest;
-
-import com.example.exodia.reservationMeeting.domain.ReservationMeet;
-import com.example.exodia.reservationMeeting.dto.ReservationMeetCreateDto;
-import com.example.exodia.reservationMeeting.dto.ReservationMeetListDto;
-import com.example.exodia.reservationMeeting.repository.ReservationMeetRepository;
-import com.example.exodia.reservationMeeting.service.ReservationMeetService;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.LockModeType;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-@SpringBootTest
-public class ReservationMeetPessimisticLockTest {
-
-    private static final Logger logger = LoggerFactory.getLogger(ReservationMeetPessimisticLockTest.class);
-
-    @Autowired
-    private ReservationMeetService reservationMeetService;
-
-    @Autowired
-    private ReservationMeetRepository reservationMeetRepository;
-
-    @Autowired
-    private EntityManager entityManager;
-
-    @Autowired
-    private EntityManagerFactory entityManagerFactory;
-
-    @Test
-    void testPessimisticLock() throws InterruptedException {
-        logger.info("===== 테스트 시작 =====");
-
-        // Given: 이미 저장된 회의실 예약 생성
-        ReservationMeetCreateDto dto = new ReservationMeetCreateDto();
-        dto.setMeetingRoomId(1L);
-        dto.setUserId(1L);
-        dto.setStartTime(LocalDateTime.of(2024, 9, 27, 10, 0));
-        dto.setEndTime(LocalDateTime.of(2024, 9, 27, 11, 0));
-        ReservationMeetListDto createdReservation = reservationMeetService.createReservation(dto);
-
-        // 스레드 풀과 CountDownLatch 설정
-        int numberOfThreads = 2;
-        ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
-        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-
-        // 각 스레드에서 동일한 시간대에 예약 시도
-        for (int i = 0; i < numberOfThreads; i++) {
-            int threadNumber = i + 1;
-            executor.execute(() -> {
-                logger.info("스레드 {} 예약 시도 시작", threadNumber);
-                try {
-                    createReservationWithPessimisticLock(createdReservation.getId());
-                    logger.info("스레드 {} 예약 성공", threadNumber);
-                } catch (Exception e) {
-                    logger.error("스레드 {} 예약 실패: {}", threadNumber, e.getMessage());
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        // 모든 스레드가 작업을 완료할 때까지 대기
-        latch.await();
-        logger.info("모든 스레드 작업 완료");
-
-        // Then: 최종 예약 개수가 1개인지 확인 (락으로 인해 중복 예약이 없어야 함)
-        long reservationCount = reservationMeetRepository.count();
-        logger.info("최종 예약 개수 확인: {}", reservationCount);
-        Assertions.assertEquals(1, reservationCount);
-
-        logger.info("===== 테스트 종료 =====");
-    }
-
-    @Transactional
-    public void createReservationWithPessimisticLock(Long reservationId) {
-        EntityManager em = entityManagerFactory.createEntityManager();
-
-        em.getTransaction().begin();
-        logger.info("트랜잭션 시작");
-
-        try {
-            logger.info("비관적 락으로 예약 조회 시도, 예약 ID: {}", reservationId);
-            ReservationMeet reservation = em.find(ReservationMeet.class, reservationId, LockModeType.PESSIMISTIC_WRITE);
-            logger.info("예약 조회 성공: {}", reservation);
-
-            // 비관적 락 테스트를 위한 인위적 지연
-            Thread.sleep(2000);
-            logger.info("2초 대기 후 트랜잭션 커밋 시도");
-            em.getTransaction().commit();
-            logger.info("트랜잭션 커밋 성공");
-        } catch (Exception e) {
-            logger.error("트랜잭션 중 오류 발생: {}", e.getMessage());
-            em.getTransaction().rollback();
-            logger.info("트랜잭션 롤백 완료");
-            throw new RuntimeException(e);
-        } finally {
-            em.close();
-            logger.info("EntityManager 닫음");
-        }
-    }
-}
+//package com.example.exodia.reservationMeetTest;
+//
+//import com.example.exodia.reservationMeeting.domain.ReservationMeet;
+//import com.example.exodia.reservationMeeting.dto.ReservationMeetCreateDto;
+//import com.example.exodia.reservationMeeting.dto.ReservationMeetListDto;
+//import com.example.exodia.reservationMeeting.repository.ReservationMeetRepository;
+//import com.example.exodia.reservationMeeting.service.ReservationMeetService;
+//import jakarta.persistence.EntityManager;
+//import jakarta.persistence.EntityManagerFactory;
+//import jakarta.persistence.LockModeType;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.Test;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.time.LocalDateTime;
+//import java.util.concurrent.CountDownLatch;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//
+//@SpringBootTest
+//public class ReservationMeetPessimisticLockTest {
+//
+//    private static final Logger logger = LoggerFactory.getLogger(ReservationMeetPessimisticLockTest.class);
+//
+//    @Autowired
+//    private ReservationMeetService reservationMeetService;
+//
+//    @Autowired
+//    private ReservationMeetRepository reservationMeetRepository;
+//
+//    @Autowired
+//    private EntityManager entityManager;
+//
+//    @Autowired
+//    private EntityManagerFactory entityManagerFactory;
+//
+//    @Test
+//    void testPessimisticLock() throws InterruptedException {
+//        logger.info("===== 테스트 시작 =====");
+//
+//        // Given: 이미 저장된 회의실 예약 생성
+//        ReservationMeetCreateDto dto = new ReservationMeetCreateDto();
+//        dto.setMeetingRoomId(1L);
+//        dto.setUserId(1L);
+//        dto.setStartTime(LocalDateTime.of(2024, 9, 27, 10, 0));
+//        dto.setEndTime(LocalDateTime.of(2024, 9, 27, 11, 0));
+//        ReservationMeetListDto createdReservation = reservationMeetService.createReservation(dto);
+//
+//        // 스레드 풀과 CountDownLatch 설정
+//        int numberOfThreads = 2;
+//        ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        // 각 스레드에서 동일한 시간대에 예약 시도
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            int threadNumber = i + 1;
+//            executor.execute(() -> {
+//                logger.info("스레드 {} 예약 시도 시작", threadNumber);
+//                try {
+//                    createReservationWithPessimisticLock(createdReservation.getId());
+//                    logger.info("스레드 {} 예약 성공", threadNumber);
+//                } catch (Exception e) {
+//                    logger.error("스레드 {} 예약 실패: {}", threadNumber, e.getMessage());
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        }
+//
+//        // 모든 스레드가 작업을 완료할 때까지 대기
+//        latch.await();
+//        logger.info("모든 스레드 작업 완료");
+//
+//        // Then: 최종 예약 개수가 1개인지 확인 (락으로 인해 중복 예약이 없어야 함)
+//        long reservationCount = reservationMeetRepository.count();
+//        logger.info("최종 예약 개수 확인: {}", reservationCount);
+//        Assertions.assertEquals(1, reservationCount);
+//
+//        logger.info("===== 테스트 종료 =====");
+//    }
+//
+//    @Transactional
+//    public void createReservationWithPessimisticLock(Long reservationId) {
+//        EntityManager em = entityManagerFactory.createEntityManager();
+//
+//        em.getTransaction().begin();
+//        logger.info("트랜잭션 시작");
+//
+//        try {
+//            logger.info("비관적 락으로 예약 조회 시도, 예약 ID: {}", reservationId);
+//            ReservationMeet reservation = em.find(ReservationMeet.class, reservationId, LockModeType.PESSIMISTIC_WRITE);
+//            logger.info("예약 조회 성공: {}", reservation);
+//
+//            // 비관적 락 테스트를 위한 인위적 지연
+//            Thread.sleep(2000);
+//            logger.info("2초 대기 후 트랜잭션 커밋 시도");
+//            em.getTransaction().commit();
+//            logger.info("트랜잭션 커밋 성공");
+//        } catch (Exception e) {
+//            logger.error("트랜잭션 중 오류 발생: {}", e.getMessage());
+//            em.getTransaction().rollback();
+//            logger.info("트랜잭션 롤백 완료");
+//            throw new RuntimeException(e);
+//        } finally {
+//            em.close();
+//            logger.info("EntityManager 닫음");
+//        }
+//    }
+//}

--- a/src/test/java/com/example/exodia/service/RegistrationServiceConcurrencyTest.java
+++ b/src/test/java/com/example/exodia/service/RegistrationServiceConcurrencyTest.java
@@ -1,0 +1,124 @@
+package com.example.exodia.service;
+
+import com.example.exodia.course.domain.Course;
+import com.example.exodia.course.dto.CourseCreateDto;
+import com.example.exodia.course.service.CourseService;
+import com.example.exodia.department.domain.Department;
+import com.example.exodia.department.repository.DepartmentRepository;
+import com.example.exodia.position.domain.Position;
+import com.example.exodia.position.repository.PositionRepository;
+import com.example.exodia.registration.service.RegistrationService;
+import com.example.exodia.user.domain.Gender;
+import com.example.exodia.user.domain.Status;
+import com.example.exodia.user.dto.UserRegisterDto;
+import com.example.exodia.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class RegistrationServiceConcurrencyTest {
+
+    @Autowired
+    private RegistrationService registrationService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private CourseService courseService;
+
+    @Autowired
+    private DepartmentRepository departmentRepository;
+
+    @Autowired
+    private PositionRepository positionRepository;
+
+    @BeforeEach
+    public void setUp() {
+        // Mocking SecurityContextHolder to simulate authenticated users in the test
+        Authentication authentication = Mockito.mock(Authentication.class);
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    public void testConcurrentRegistrations() throws Exception {
+        // Step 1: Create 10000 users in the system
+        createTestUsers(10000);
+
+        // Step 2: Create a course with a maxParticipants limit of 100
+        CourseCreateDto courseCreateDto = new CourseCreateDto();
+        courseCreateDto.setCourseName("Test Course");
+        courseCreateDto.setCourseUrl("http://example.com");
+        courseCreateDto.setMaxParticipants(100);
+        Course createdCourse = courseService.createCourse(courseCreateDto);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(100);
+        List<Future<?>> futures = new ArrayList<>();
+
+        // Step 3: 10000 users attempt to register for the course
+        IntStream.rangeClosed(1, 10000).forEach(i -> {
+            Future<?> future = executorService.submit(() -> {
+                // Simulate different users by setting userNum manually
+                String userNum = "2024" + String.format("%06d", i);
+
+                // Mock the authenticated user in the SecurityContext
+                Authentication authentication = Mockito.mock(Authentication.class);
+                Mockito.when(authentication.getName()).thenReturn(userNum);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                // Step 4: Each user tries to register for the course
+                registrationService.registerParticipant(createdCourse.getId());
+            });
+            futures.add(future);
+        });
+
+        // Step 5: Wait for all tasks to complete
+        for (Future<?> future : futures) {
+            future.get();
+        }
+        executorService.shutdown();
+
+        // Step 6: Validate that only 100 users were successfully registered
+        assertEquals(100, registrationService.getConfirmedParticipants(createdCourse.getId()).size(), "Ensure only 100 users registered successfully");
+    }
+
+    // Method to create test users for the system
+    public void createTestUsers(int numberOfUsers) {
+        Department testDepartment = departmentRepository.findByName("경영1팀")
+                .orElseThrow(() -> new RuntimeException("경영1팀 존재하지 않습니다."));
+        Position testPosition = positionRepository.findByName("사원")
+                .orElseThrow(() -> new RuntimeException("사원 직급이 존재하지 않습니다."));
+
+        for (int i = 1; i <= numberOfUsers; i++) {
+            UserRegisterDto registerDto = new UserRegisterDto();
+            registerDto.setUserNum("2024" + String.format("%06d", i));
+            registerDto.setName("테스트유저" + i);
+            registerDto.setDepartmentId(testDepartment.getId());
+            registerDto.setPositionId(testPosition.getId());
+            registerDto.setPassword("password" + i);
+            registerDto.setEmail("testuser" + i + "@example.com");
+            registerDto.setPhone("010-1234-" + String.format("%04d", i));
+            registerDto.setSocialNum("123456-1234567");
+
+            // Register the user
+            userService.registerUser(registerDto, null, testDepartment.getId().toString());
+        }
+    }
+}

--- a/src/test/java/com/example/exodia/service/RegistrationServiceConcurrencyTest.java
+++ b/src/test/java/com/example/exodia/service/RegistrationServiceConcurrencyTest.java
@@ -1,124 +1,124 @@
-package com.example.exodia.service;
-
-import com.example.exodia.course.domain.Course;
-import com.example.exodia.course.dto.CourseCreateDto;
-import com.example.exodia.course.service.CourseService;
-import com.example.exodia.department.domain.Department;
-import com.example.exodia.department.repository.DepartmentRepository;
-import com.example.exodia.position.domain.Position;
-import com.example.exodia.position.repository.PositionRepository;
-import com.example.exodia.registration.service.RegistrationService;
-import com.example.exodia.user.domain.Gender;
-import com.example.exodia.user.domain.Status;
-import com.example.exodia.user.dto.UserRegisterDto;
-import com.example.exodia.user.service.UserService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.IntStream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-@SpringBootTest
-public class RegistrationServiceConcurrencyTest {
-
-    @Autowired
-    private RegistrationService registrationService;
-
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private CourseService courseService;
-
-    @Autowired
-    private DepartmentRepository departmentRepository;
-
-    @Autowired
-    private PositionRepository positionRepository;
-
-    @BeforeEach
-    public void setUp() {
-        // Mocking SecurityContextHolder to simulate authenticated users in the test
-        Authentication authentication = Mockito.mock(Authentication.class);
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-    }
-
-    @Test
-    public void testConcurrentRegistrations() throws Exception {
-        // Step 1: Create 10000 users in the system
-        createTestUsers(10000);
-
-        // Step 2: Create a course with a maxParticipants limit of 100
-        CourseCreateDto courseCreateDto = new CourseCreateDto();
-        courseCreateDto.setCourseName("Test Course");
-        courseCreateDto.setCourseUrl("http://example.com");
-        courseCreateDto.setMaxParticipants(100);
-        Course createdCourse = courseService.createCourse(courseCreateDto);
-
-        ExecutorService executorService = Executors.newFixedThreadPool(100);
-        List<Future<?>> futures = new ArrayList<>();
-
-        // Step 3: 10000 users attempt to register for the course
-        IntStream.rangeClosed(1, 10000).forEach(i -> {
-            Future<?> future = executorService.submit(() -> {
-                // Simulate different users by setting userNum manually
-                String userNum = "2024" + String.format("%06d", i);
-
-                // Mock the authenticated user in the SecurityContext
-                Authentication authentication = Mockito.mock(Authentication.class);
-                Mockito.when(authentication.getName()).thenReturn(userNum);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-
-                // Step 4: Each user tries to register for the course
-                registrationService.registerParticipant(createdCourse.getId());
-            });
-            futures.add(future);
-        });
-
-        // Step 5: Wait for all tasks to complete
-        for (Future<?> future : futures) {
-            future.get();
-        }
-        executorService.shutdown();
-
-        // Step 6: Validate that only 100 users were successfully registered
-        assertEquals(100, registrationService.getConfirmedParticipants(createdCourse.getId()).size(), "Ensure only 100 users registered successfully");
-    }
-
-    // Method to create test users for the system
-    public void createTestUsers(int numberOfUsers) {
-        Department testDepartment = departmentRepository.findByName("경영1팀")
-                .orElseThrow(() -> new RuntimeException("경영1팀 존재하지 않습니다."));
-        Position testPosition = positionRepository.findByName("사원")
-                .orElseThrow(() -> new RuntimeException("사원 직급이 존재하지 않습니다."));
-
-        for (int i = 1; i <= numberOfUsers; i++) {
-            UserRegisterDto registerDto = new UserRegisterDto();
-            registerDto.setUserNum("2024" + String.format("%06d", i));
-            registerDto.setName("테스트유저" + i);
-            registerDto.setDepartmentId(testDepartment.getId());
-            registerDto.setPositionId(testPosition.getId());
-            registerDto.setPassword("password" + i);
-            registerDto.setEmail("testuser" + i + "@example.com");
-            registerDto.setPhone("010-1234-" + String.format("%04d", i));
-            registerDto.setSocialNum("123456-1234567");
-
-            // Register the user
-            userService.registerUser(registerDto, null, testDepartment.getId().toString());
-        }
-    }
-}
+//package com.example.exodia.service;
+//
+//import com.example.exodia.course.domain.Course;
+//import com.example.exodia.course.dto.CourseCreateDto;
+//import com.example.exodia.course.service.CourseService;
+//import com.example.exodia.department.domain.Department;
+//import com.example.exodia.department.repository.DepartmentRepository;
+//import com.example.exodia.position.domain.Position;
+//import com.example.exodia.position.repository.PositionRepository;
+//import com.example.exodia.registration.service.RegistrationService;
+//import com.example.exodia.user.domain.Gender;
+//import com.example.exodia.user.domain.HireType;
+//import com.example.exodia.user.domain.NowStatus;
+//import com.example.exodia.user.domain.Status;
+//import com.example.exodia.user.dto.UserRegisterDto;
+//import com.example.exodia.user.service.UserService;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.Mockito;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.context.SecurityContext;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//import java.util.concurrent.Future;
+//import java.util.stream.IntStream;
+//
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//
+//
+//@SpringBootTest
+//public class RegistrationServiceConcurrencyTest {
+//
+//    @Autowired
+//    private RegistrationService registrationService;
+//
+//    @Autowired
+//    private UserService userService;
+//
+//    @Autowired
+//    private CourseService courseService;
+//
+//    @Autowired
+//    private DepartmentRepository departmentRepository;
+//
+//    @Autowired
+//    private PositionRepository positionRepository;
+//
+//    @BeforeEach
+//    public void setUp() {
+//        Authentication authentication = Mockito.mock(Authentication.class);
+//        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+//        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+//        Mockito.when(authentication.getName()).thenReturn("20240901001");
+//        SecurityContextHolder.setContext(securityContext);
+//    }
+//
+//    @Test
+//    public void testConcurrentRegistrations() throws Exception {
+//        createTestUsers(500);
+//
+//        // Step 2: 관리자 권한으로 강좌 생성
+//        CourseCreateDto courseCreateDto = new CourseCreateDto();
+//        courseCreateDto.setCourseName("Test Course");
+//        courseCreateDto.setCourseUrl("http://example.com");
+//        courseCreateDto.setMaxParticipants(100);
+//
+//        // 관리자 권한을 가진 사용자로 강좌 생성
+//        Course createdCourse = courseService.createCourse(courseCreateDto);
+//
+//        ExecutorService executorService = Executors.newFixedThreadPool(100);
+//        List<Future<?>> futures = new ArrayList<>();
+//
+//        IntStream.rangeClosed(1, 500).forEach(i -> {
+//            Future<?> future = executorService.submit(() -> {
+//                String userNum = "2024" + String.format("%06d", i);
+//
+//                Authentication userAuthentication = Mockito.mock(Authentication.class);
+//                Mockito.when(userAuthentication.getName()).thenReturn(userNum);
+//                SecurityContextHolder.getContext().setAuthentication(userAuthentication);
+//
+//                registrationService.registerParticipant(createdCourse.getId());
+//            });
+//            futures.add(future);
+//        });
+//
+//        for (Future<?> future : futures) {
+//            future.get();
+//        }
+//        executorService.shutdown();
+//
+//        assertEquals(100, registrationService.getConfirmedParticipants(createdCourse.getId()).size(), "Ensure only 100 users registered successfully");
+//    }
+//
+//    public void createTestUsers(int numberOfUsers) {
+//        Department testDepartment = departmentRepository.findByName("경영1팀")
+//                .orElseThrow(() -> new RuntimeException("경영1팀 존재하지 않습니다."));
+//        Position testPosition = positionRepository.findByName("사원")
+//                .orElseThrow(() -> new RuntimeException("사원 직급이 존재하지 않습니다."));
+//
+//        for (int i = 1; i <= numberOfUsers; i++) {
+//            UserRegisterDto registerDto = new UserRegisterDto();
+//            registerDto.setUserNum("2024" + String.format("%06d", i));
+//            registerDto.setName("테스트유저" + i);
+//            registerDto.setDepartmentId(testDepartment.getId());
+//            registerDto.setPositionId(testPosition.getId());
+//
+//            registerDto.setGender(Gender.M);
+//            registerDto.setHireType(HireType.정규직);
+//            registerDto.setStatus(Status.재직);
+//            registerDto.setPassword("password" + i);
+//            registerDto.setEmail("testuser" + i + "@example.com");
+//            registerDto.setPhone("01012341234");
+//            registerDto.setSocialNum("123456-1234567");
+//
+//            userService.registerUser(registerDto, null, testDepartment.getId().toString());
+//        }
+//    }
+//}

--- a/src/test/java/com/example/exodia/service/RegistrationServiceTest.java
+++ b/src/test/java/com/example/exodia/service/RegistrationServiceTest.java
@@ -1,0 +1,97 @@
+//package com.example.exodia.service;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.*;
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//import com.example.exodia.common.service.KafkaProducer;
+//import com.example.exodia.course.domain.Course;
+//import com.example.exodia.course.repository.CourseRepository;
+//import com.example.exodia.registration.service.RegistrationService;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.core.ValueOperations;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Optional;
+//import java.util.concurrent.*;
+//import java.util.concurrent.atomic.AtomicInteger;
+//
+//class RegistrationServiceTest {
+//
+//    @Mock
+//    private RedisTemplate<String, Object> redisTemplate;
+//
+//    @Mock
+//    private ValueOperations<String, Object> valueOperations;
+//
+//    @Mock
+//    private KafkaProducer kafkaProducer;
+//
+//    @Mock
+//    private CourseRepository courseRepository;
+//
+//    @InjectMocks
+//    private RegistrationService registrationService;
+//
+//    private final int maxParticipants = 100;
+//    private final AtomicInteger currentParticipants = new AtomicInteger(0); // 현재 참가자 수
+//
+//    @BeforeEach
+//    void setUp() {
+//        MockitoAnnotations.openMocks(this);
+//        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+//    }
+//
+//    @Test
+//    void testConcurrentUserRegistration() throws InterruptedException, ExecutionException {
+//
+//        Course mockCourse = new Course();
+//        mockCourse.setMaxParticipants(maxParticipants);
+//        when(courseRepository.findById(anyLong())).thenReturn(Optional.of(mockCourse));
+//
+//        when(valueOperations.increment(anyString())).thenAnswer(invocation -> (long) currentParticipants.incrementAndGet());
+//
+//        // 10,000명의 사용자 처리하기 위해 ExecutorService 사용
+//        ExecutorService executorService = Executors.newFixedThreadPool(100); // 100개의 스레드 풀
+//        List<Callable<String>> tasks = new ArrayList<>();
+//
+//        // 10,000명의 사용자 등록 시도
+//        for (int i = 1; i <= 10000; i++) {
+//            final long userId = i;
+//            tasks.add(() -> {
+//                synchronized (currentParticipants) {
+//                    String result = registrationService.registerParticipant(1L, userId);
+//                    // 성공한 사람만 출력
+//                    if ("등록 완료".equals(result)) {
+//                        int current = currentParticipants.get();
+//                        System.out.println("User " + userId + "가 등록에 성공했습니다. (" + current + "/" + maxParticipants + ")");
+//                    } else {
+//                        System.out.println("User " + userId + "가 등록에 실패했습니다.");
+//                    }
+//                    return result;
+//                }
+//            });
+//        }
+//
+//        // 10,000명의 사용자 등록 요청 실행
+//        List<Future<String>> futures = executorService.invokeAll(tasks);
+//        executorService.shutdown();
+//
+//        // 성공한 사용자 수 확인
+//        long successCount = futures.stream().filter(future -> {
+//            try {
+//                return "등록 완료".equals(future.get());
+//            } catch (Exception e) {
+//                return false;
+//            }
+//        }).count();
+//
+//        // 성공한 사용자 수가 정확히 100명인지 확인
+//        assertEquals(maxParticipants, successCount);
+//    }
+//}


### PR DESCRIPTION
강좌 관련 동시성 제어
kafka+ redis
redis 으로 count 제어
kafka 으로 신청 유저 저장 제어(유실방지)

-동시성 테스트 : securityContextHolder 을 제외한 user1~user10000 까지의 선착순 제어 완(完)
-동시성 테스트 : 토큰 값을 받은 뒤 (유저 정보 모두 입력 후) 해당 유저에 대한 선착순 제어 전(前)

kafka 확인
docker exec -it <kafka container id> /bin/bash
kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic course-registration --from-beginning

redis 인원 수 제어
docker exec -it <redis name > redis-cli
select 11
course:<courseId>:participants